### PR TITLE
Potential fix for code scanning alert no. 4: Client-side URL redirect

### DIFF
--- a/apps/public-frontend/app/auth/callback/page.tsx
+++ b/apps/public-frontend/app/auth/callback/page.tsx
@@ -69,11 +69,13 @@ export default function AuthCallbackPage() {
 
         // Get the redirect URL
         const params = new URLSearchParams(window.location.search);
-        const redirectTo = params.get('redirect') || '/dashboard';
-        console.log('➡️ [Auth] Redirecting to:', redirectTo);
+        const redirectTo = params.get('redirect');
+        const allowedPaths = ['/dashboard', '/profile', '/settings']; // Whitelisted paths
+        const safeRedirectTo = redirectTo && allowedPaths.includes(redirectTo) ? redirectTo : '/dashboard';
+        console.log('➡️ [Auth] Redirecting to:', safeRedirectTo);
 
         // Redirect to the target URL
-        safeRedirect(redirectTo);
+        safeRedirect(safeRedirectTo);
       } catch (e) {
         console.error('❌ [Auth] Unexpected error:', e);
         setError(e as Error);

--- a/apps/public-frontend/app/auth/callback/page.tsx
+++ b/apps/public-frontend/app/auth/callback/page.tsx
@@ -71,7 +71,18 @@ export default function AuthCallbackPage() {
         const params = new URLSearchParams(window.location.search);
         const redirectTo = params.get('redirect');
         const allowedPaths = ['/dashboard', '/profile', '/settings']; // Whitelisted paths
-        const safeRedirectTo = redirectTo && allowedPaths.includes(redirectTo) ? redirectTo : '/dashboard';
+        let safeRedirectTo = '/dashboard'; // Default redirect
+        if (redirectTo) {
+          try {
+            const redirectUrl = new URL(redirectTo, window.location.origin); // Parse URL
+            const redirectPathname = redirectUrl.pathname; // Extract pathname
+            if (allowedPaths.includes(redirectPathname)) {
+              safeRedirectTo = redirectPathname; // Use sanitized pathname
+            }
+          } catch (e) {
+            console.error('❌ [Auth] Invalid redirect URL:', redirectTo, e);
+          }
+        }
         console.log('➡️ [Auth] Redirecting to:', safeRedirectTo);
 
         // Redirect to the target URL


### PR DESCRIPTION
Potential fix for [https://github.com/fuzzylim/rally-round-ai/security/code-scanning/4](https://github.com/fuzzylim/rally-round-ai/security/code-scanning/4)

To fix the issue, we need to validate the `redirect` parameter to ensure it points to a trusted URL. A common approach is to maintain a whitelist of allowed paths or domains and check the `redirect` parameter against this list. If the parameter is not valid, we should redirect to a safe default (e.g., `/dashboard`).

Steps to implement the fix:
1. Create a whitelist of allowed paths or domains.
2. Validate the `redirect` parameter against this whitelist.
3. If the `redirect` parameter is invalid or not present, use the safe default (`/dashboard`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
